### PR TITLE
Allow more than 9 captures in path regexes.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl extension Tatsumaki
 
+        - Allow more than 9 captures in path regexes (plu)
+
 0.1013  Thu Jul  7 11:49:18 PDT 2011
         - Added $self->binary(1) in Handler classes to indicate binary responses (gbarr, mateu)
         - Allow $self->json to be set to customize the way JSON is encoded (ask)

--- a/lib/Tatsumaki/Application.pm
+++ b/lib/Tatsumaki/Application.pm
@@ -50,9 +50,9 @@ sub dispatch {
 
     my $path = $req->path_info;
     for my $rule (@{$self->_rules}) {
-        if ($path =~ $rule->{path}) {
-            my $args = [ $1, $2, $3, $4, $5, $6, $7, $8, $9 ];
-            return $rule->{handler}->new(application => $self, request => $req, args => $args);
+        my @args = $path =~ $rule->{path};
+        if (@args) {
+            return $rule->{handler}->new(application => $self, request => $req, args => \@args);
         }
     }
 

--- a/t/handler/captures.t
+++ b/t/handler/captures.t
@@ -1,0 +1,28 @@
+package CaptureApp;
+use base qw(Tatsumaki::Handler);
+
+sub get {
+    my ($self, @params) = @_;
+    $self->response->content_type('text/plain; charset=latin-1');
+    $self->write(scalar @params);
+}
+
+package main;
+use Plack::Test;
+use Test::More;
+use HTTP::Request::Common;
+use Tatsumaki::Application;
+$Plack::Test::Impl = "Server";
+
+my $app = Tatsumaki::Application->new([
+    '/capture/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/'  => 'CaptureApp',
+]);
+
+test_psgi $app, sub {
+    my $cb = shift;
+
+    my $res = $cb->(GET "http://localhost/capture/1/2/3/4/5/6/7/8/9/10/");
+    is $res->content, "10";
+};
+
+done_testing;


### PR DESCRIPTION
Currently there are only 9 captures supported due to that code:

`my $args = [ $1, $2, $3, $4, $5, $6, $7, $8, $9 ];`

This pull request fixes this limitation and adds a test for it.
