### PR TITLE
Any::Moose is deprecated. use Moose instead.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 Revision history for Perl extension Tatsumaki
 
+        - use Moose instead. Any::Moose is deprecated. (gugod)
         - Allow more than 9 captures in path regexes (plu)
 
 0.1013  Thu Jul  7 11:49:18 PDT 2011

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -4,7 +4,7 @@ all_from 'lib/Tatsumaki.pm';
 readme_from 'lib/Tatsumaki.pm';
 requires 'AnyEvent', '5.2';
 requires 'AnyEvent::HTTP';
-requires 'Any::Moose';
+requires 'Moose';
 requires 'Mouse', 0.34;
 requires 'Plack', 0.9913;
 requires 'Twiggy';

--- a/lib/Tatsumaki/Application.pm
+++ b/lib/Tatsumaki/Application.pm
@@ -1,6 +1,6 @@
 package Tatsumaki::Application;
 use AnyEvent;
-use Any::Moose;
+use Moose;
 use Tatsumaki::Handler;
 use Tatsumaki::Request;
 use Try::Tiny;
@@ -141,7 +141,7 @@ sub _service_name_for {
     return $name;
 }
 
-no Any::Moose;
+no Moose;
 __PACKAGE__->meta->make_immutable;
 
 1;

--- a/lib/Tatsumaki/Error.pm
+++ b/lib/Tatsumaki/Error.pm
@@ -1,6 +1,6 @@
 package Tatsumaki::Error;
 use strict;
-use Any::Moose;
+use Moose;
 
 sub throw {
     my($class, @rest) = @_;
@@ -8,11 +8,11 @@ sub throw {
 }
 
 package Tatsumaki::Error::ClientDisconnect;
-use Any::Moose;
+use Moose;
 extends 'Tatsumaki::Error';
 
 package Tatsumaki::Error::HTTP;
-use Any::Moose;
+use Moose;
 use HTTP::Status;
 extends 'Tatsumaki::Error';
 

--- a/lib/Tatsumaki/HTTPClient.pm
+++ b/lib/Tatsumaki/HTTPClient.pm
@@ -5,7 +5,7 @@ use HTTP::Request::Common ();
 use HTTP::Request;
 use HTTP::Response;
 use Tatsumaki;
-use Any::Moose;
+use Moose;
 
 has timeout => (is => 'rw', isa => 'Int', default => sub { 30 });
 has agent   => (is => 'rw', isa => 'Str', default => sub { join "/", __PACKAGE__, $Tatsumaki::VERSION });
@@ -44,7 +44,7 @@ sub request {
     };
 }
 
-no Any::Moose;
+no Moose;
 __PACKAGE__->meta->make_immutable;
 
 1;

--- a/lib/Tatsumaki/Handler.pm
+++ b/lib/Tatsumaki/Handler.pm
@@ -3,7 +3,7 @@ use strict;
 use AnyEvent;
 use Carp ();
 use Encode ();
-use Any::Moose;
+use Moose;
 use MIME::Base64 ();
 use JSON;
 use Try::Tiny;
@@ -240,7 +240,7 @@ sub render {
     $self->finish($self->application->render_file($file, { %$args, handler => $self })->as_string);
 }
 
-no Any::Moose;
+no Moose;
 __PACKAGE__->meta->make_immutable;
 
 1;

--- a/lib/Tatsumaki/MessageQueue.pm
+++ b/lib/Tatsumaki/MessageQueue.pm
@@ -2,7 +2,7 @@ package Tatsumaki::MessageQueue;
 use strict;
 
 use AnyEvent;
-use Any::Moose;
+use Moose;
 use Try::Tiny;
 use Scalar::Util;
 use Time::HiRes;

--- a/lib/Tatsumaki/Service.pm
+++ b/lib/Tatsumaki/Service.pm
@@ -1,5 +1,5 @@
 package Tatsumaki::Service;
-use Any::Moose;
+use Moose;
 
 has application => (is => 'rw', isa => 'Tatsumaki::Application', weak_ref => 1);
 

--- a/lib/Tatsumaki/Template.pm
+++ b/lib/Tatsumaki/Template.pm
@@ -1,5 +1,5 @@
 package Tatsumaki::Template;
-use Any::Moose;
+use Moose;
 
 sub render_file;
 sub include_path;

--- a/lib/Tatsumaki/Template/Micro.pm
+++ b/lib/Tatsumaki/Template/Micro.pm
@@ -1,5 +1,5 @@
 package Tatsumaki::Template::Micro;
-use Any::Moose;
+use Moose;
 extends 'Tatsumaki::Template';
 
 use Text::MicroTemplate::File;


### PR DESCRIPTION
Hey @miyagawa ,

Using Any::Moose would trigger a bunch of deprecation warnings these days. Replace the use of `Any::Moose` with `use Moose` seems to be the easiest choice for this project.
